### PR TITLE
Add StopSequence field to Departure model

### DIFF
--- a/NextDepartures.Standard/Models/Departure.cs
+++ b/NextDepartures.Standard/Models/Departure.cs
@@ -14,6 +14,9 @@ public class Departure
     
     [UsedImplicitly]
     public string StopId { get; set; }
+
+    [UsedImplicitly]
+    public int StopSequence { get; set; }
     
     [UsedImplicitly]
     public string TripId { get; set; }

--- a/NextDepartures.Standard/Models/Departure.cs
+++ b/NextDepartures.Standard/Models/Departure.cs
@@ -16,7 +16,7 @@ public class Departure
     public string StopId { get; set; }
 
     [UsedImplicitly]
-    public int StopSequence { get; set; }
+    public short StopSequence { get; set; }
     
     [UsedImplicitly]
     public string TripId { get; set; }

--- a/NextDepartures.Storage.GTFS/GtfsStorage.cs
+++ b/NextDepartures.Storage.GTFS/GtfsStorage.cs
@@ -96,7 +96,7 @@ public class GtfsStorage : IDataStorage
                 },
                 
                 StopId = e.s.StopId?.TrimDoubleQuotes(),
-                StopSequence = (int)e.s.StopSequence,
+                StopSequence = (short)e.s.StopSequence,
                 TripId = e.t.Id.TrimDoubleQuotes(),
                 ServiceId = e.t.ServiceId.TrimDoubleQuotes(),
                 TripHeadsign = e.t.Headsign?.TrimDoubleQuotes(),

--- a/NextDepartures.Storage.GTFS/GtfsStorage.cs
+++ b/NextDepartures.Storage.GTFS/GtfsStorage.cs
@@ -96,6 +96,7 @@ public class GtfsStorage : IDataStorage
                 },
                 
                 StopId = e.s.StopId?.TrimDoubleQuotes(),
+                StopSequence = (int)e.s.StopSequence,
                 TripId = e.t.Id.TrimDoubleQuotes(),
                 ServiceId = e.t.ServiceId.TrimDoubleQuotes(),
                 TripHeadsign = e.t.Headsign?.TrimDoubleQuotes(),

--- a/NextDepartures.Storage.MySql/MySqlStorage.cs
+++ b/NextDepartures.Storage.MySql/MySqlStorage.cs
@@ -110,22 +110,23 @@ public class MySqlStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            TripId = dataReader.GetString(ordinal: 2),
-            ServiceId = dataReader.GetString(ordinal: 3),
-            TripHeadsign = !dataReader.IsDBNull(ordinal: 4) ? dataReader.GetString(ordinal: 4) : null,
-            TripShortName = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
-            AgencyId = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
-            RouteShortName = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
-            RouteLongName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
-            Monday = dataReader.GetInt16(ordinal: 9).ToBool(),
-            Tuesday = dataReader.GetInt16(ordinal: 10).ToBool(),
-            Wednesday = dataReader.GetInt16(ordinal: 11).ToBool(),
-            Thursday = dataReader.GetInt16(ordinal: 12).ToBool(),
-            Friday = dataReader.GetInt16(ordinal: 13).ToBool(),
-            Saturday = dataReader.GetInt16(ordinal: 14).ToBool(),
-            Sunday = dataReader.GetInt16(ordinal: 15).ToBool(),
-            StartDate = dataReader.GetDateTime(ordinal: 16),
-            EndDate = dataReader.GetDateTime(ordinal: 17)
+            StopSequence = dataReader.GetInt32(ordinal: 2),
+            TripId = dataReader.GetString(ordinal: 3),
+            ServiceId = dataReader.GetString(ordinal: 4),
+            TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
+            TripShortName = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
+            AgencyId = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
+            RouteShortName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
+            RouteLongName = !dataReader.IsDBNull(ordinal: 9) ? dataReader.GetString(ordinal: 9) : null,
+            Monday = dataReader.GetInt16(ordinal: 10).ToBool(),
+            Tuesday = dataReader.GetInt16(ordinal: 11).ToBool(),
+            Wednesday = dataReader.GetInt16(ordinal: 12).ToBool(),
+            Thursday = dataReader.GetInt16(ordinal: 13).ToBool(),
+            Friday = dataReader.GetInt16(ordinal: 14).ToBool(),
+            Saturday = dataReader.GetInt16(ordinal: 15).ToBool(),
+            Sunday = dataReader.GetInt16(ordinal: 16).ToBool(),
+            StartDate = dataReader.GetDateTime(ordinal: 17),
+            EndDate = dataReader.GetDateTime(ordinal: 18)
         };
     }
     
@@ -465,6 +466,7 @@ public class MySqlStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -491,6 +493,7 @@ public class MySqlStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -517,6 +520,7 @@ public class MySqlStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -543,6 +547,7 @@ public class MySqlStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +
@@ -579,6 +584,7 @@ public class MySqlStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -605,6 +611,7 @@ public class MySqlStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -631,6 +638,7 @@ public class MySqlStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -657,6 +665,7 @@ public class MySqlStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +

--- a/NextDepartures.Storage.MySql/MySqlStorage.cs
+++ b/NextDepartures.Storage.MySql/MySqlStorage.cs
@@ -110,7 +110,7 @@ public class MySqlStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            StopSequence = dataReader.GetInt32(ordinal: 2),
+            StopSequence = dataReader.GetInt16(ordinal: 2),
             TripId = dataReader.GetString(ordinal: 3),
             ServiceId = dataReader.GetString(ordinal: 4),
             TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,

--- a/NextDepartures.Storage.Postgres.Aspire/PostgresStorage.cs
+++ b/NextDepartures.Storage.Postgres.Aspire/PostgresStorage.cs
@@ -125,7 +125,7 @@ public class PostgresStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            StopSequence = dataReader.GetInt32(ordinal: 2),
+            StopSequence = dataReader.GetInt16(ordinal: 2),
             TripId = dataReader.GetString(ordinal: 3),
             ServiceId = dataReader.GetString(ordinal: 4),
             TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,

--- a/NextDepartures.Storage.Postgres.Aspire/PostgresStorage.cs
+++ b/NextDepartures.Storage.Postgres.Aspire/PostgresStorage.cs
@@ -125,22 +125,23 @@ public class PostgresStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            TripId = dataReader.GetString(ordinal: 2),
-            ServiceId = dataReader.GetString(ordinal: 3),
-            TripHeadsign = !dataReader.IsDBNull(ordinal: 4) ? dataReader.GetString(ordinal: 4) : null,
-            TripShortName = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
-            AgencyId = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
-            RouteShortName = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
-            RouteLongName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
-            Monday = dataReader.GetInt16(ordinal: 9).ToBool(),
-            Tuesday = dataReader.GetInt16(ordinal: 10).ToBool(),
-            Wednesday = dataReader.GetInt16(ordinal: 11).ToBool(),
-            Thursday = dataReader.GetInt16(ordinal: 12).ToBool(),
-            Friday = dataReader.GetInt16(ordinal: 13).ToBool(),
-            Saturday = dataReader.GetInt16(ordinal: 14).ToBool(),
-            Sunday = dataReader.GetInt16(ordinal: 15).ToBool(),
-            StartDate = dataReader.GetDateTime(ordinal: 16),
-            EndDate = dataReader.GetDateTime(ordinal: 17)
+            StopSequence = dataReader.GetInt32(ordinal: 2),
+            TripId = dataReader.GetString(ordinal: 3),
+            ServiceId = dataReader.GetString(ordinal: 4),
+            TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
+            TripShortName = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
+            AgencyId = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
+            RouteShortName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
+            RouteLongName = !dataReader.IsDBNull(ordinal: 9) ? dataReader.GetString(ordinal: 9) : null,
+            Monday = dataReader.GetInt16(ordinal: 10).ToBool(),
+            Tuesday = dataReader.GetInt16(ordinal: 11).ToBool(),
+            Wednesday = dataReader.GetInt16(ordinal: 12).ToBool(),
+            Thursday = dataReader.GetInt16(ordinal: 13).ToBool(),
+            Friday = dataReader.GetInt16(ordinal: 14).ToBool(),
+            Saturday = dataReader.GetInt16(ordinal: 15).ToBool(),
+            Sunday = dataReader.GetInt16(ordinal: 16).ToBool(),
+            StartDate = dataReader.GetDateTime(ordinal: 17),
+            EndDate = dataReader.GetDateTime(ordinal: 18)
         };
     }
     
@@ -480,6 +481,7 @@ public class PostgresStorage : IDataStorage
         {
             ComparisonType.Partial => "select s.departure_time, " +
                                              "s.stop_id, " +
+                                             "s.stop_sequence, " +
                                              "t.trip_id, " +
                                              "t.service_id, " +
                                              "t.trip_headsign, " +
@@ -506,6 +508,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Starts => "select s.departure_time, " +
                                             "s.stop_id, " +
+                                            "s.stop_sequence, " +
                                             "t.trip_id, " +
                                             "t.service_id, " +
                                             "t.trip_headsign, " +
@@ -532,6 +535,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Ends => "select s.departure_time, " +
                                           "s.stop_id, " +
+                                          "s.stop_sequence, " +
                                           "t.trip_id, " +
                                           "t.service_id, " +
                                           "t.trip_headsign, " +
@@ -558,6 +562,7 @@ public class PostgresStorage : IDataStorage
             
             _ => "select s.departure_time, " +
                         "s.stop_id, " +
+                        "s.stop_sequence, " +
                         "t.trip_id, " +
                         "t.service_id, " +
                         "t.trip_headsign, " +
@@ -594,6 +599,7 @@ public class PostgresStorage : IDataStorage
         {
             ComparisonType.Partial => "select s.departure_time, " +
                                              "s.stop_id, " +
+                                             "s.stop_sequence, " +
                                              "t.trip_id, " +
                                              "t.service_id, " +
                                              "t.trip_headsign, " +
@@ -620,6 +626,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Starts => "select s.departure_time, " +
                                             "s.stop_id, " +
+                                            "s.stop_sequence, " +
                                             "t.trip_id, " +
                                             "t.service_id, " +
                                             "t.trip_headsign, " +
@@ -646,6 +653,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Ends => "select s.departure_time, " +
                                           "s.stop_id, " +
+                                          "s.stop_sequence, " +
                                           "t.trip_id, " +
                                           "t.service_id, " +
                                           "t.trip_headsign, " +
@@ -672,6 +680,7 @@ public class PostgresStorage : IDataStorage
             
             _ => "select s.departure_time, " +
                         "s.stop_id, " +
+                        "s.stop_sequence, " +
                         "t.trip_id, " +
                         "t.service_id, " +
                         "t.trip_headsign, " +

--- a/NextDepartures.Storage.Postgres/PostgresStorage.cs
+++ b/NextDepartures.Storage.Postgres/PostgresStorage.cs
@@ -110,7 +110,7 @@ public class PostgresStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            StopSequence = dataReader.GetInt32(ordinal: 2),
+            StopSequence = dataReader.GetInt16(ordinal: 2),
             TripId = dataReader.GetString(ordinal: 3),
             ServiceId = dataReader.GetString(ordinal: 4),
             TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,

--- a/NextDepartures.Storage.Postgres/PostgresStorage.cs
+++ b/NextDepartures.Storage.Postgres/PostgresStorage.cs
@@ -110,22 +110,23 @@ public class PostgresStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            TripId = dataReader.GetString(ordinal: 2),
-            ServiceId = dataReader.GetString(ordinal: 3),
-            TripHeadsign = !dataReader.IsDBNull(ordinal: 4) ? dataReader.GetString(ordinal: 4) : null,
-            TripShortName = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
-            AgencyId = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
-            RouteShortName = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
-            RouteLongName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
-            Monday = dataReader.GetInt16(ordinal: 9).ToBool(),
-            Tuesday = dataReader.GetInt16(ordinal: 10).ToBool(),
-            Wednesday = dataReader.GetInt16(ordinal: 11).ToBool(),
-            Thursday = dataReader.GetInt16(ordinal: 12).ToBool(),
-            Friday = dataReader.GetInt16(ordinal: 13).ToBool(),
-            Saturday = dataReader.GetInt16(ordinal: 14).ToBool(),
-            Sunday = dataReader.GetInt16(ordinal: 15).ToBool(),
-            StartDate = dataReader.GetDateTime(ordinal: 16),
-            EndDate = dataReader.GetDateTime(ordinal: 17)
+            StopSequence = dataReader.GetInt32(ordinal: 2),
+            TripId = dataReader.GetString(ordinal: 3),
+            ServiceId = dataReader.GetString(ordinal: 4),
+            TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
+            TripShortName = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
+            AgencyId = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
+            RouteShortName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
+            RouteLongName = !dataReader.IsDBNull(ordinal: 9) ? dataReader.GetString(ordinal: 9) : null,
+            Monday = dataReader.GetInt16(ordinal: 10).ToBool(),
+            Tuesday = dataReader.GetInt16(ordinal: 11).ToBool(),
+            Wednesday = dataReader.GetInt16(ordinal: 12).ToBool(),
+            Thursday = dataReader.GetInt16(ordinal: 13).ToBool(),
+            Friday = dataReader.GetInt16(ordinal: 14).ToBool(),
+            Saturday = dataReader.GetInt16(ordinal: 15).ToBool(),
+            Sunday = dataReader.GetInt16(ordinal: 16).ToBool(),
+            StartDate = dataReader.GetDateTime(ordinal: 17),
+            EndDate = dataReader.GetDateTime(ordinal: 18)
         };
     }
     
@@ -465,6 +466,7 @@ public class PostgresStorage : IDataStorage
         {
             ComparisonType.Partial => "select s.departure_time, " +
                                              "s.stop_id, " +
+                                             "s.stop_sequence, " +
                                              "t.trip_id, " +
                                              "t.service_id, " +
                                              "t.trip_headsign, " +
@@ -491,6 +493,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Starts => "select s.departure_time, " +
                                             "s.stop_id, " +
+                                            "s.stop_sequence, " +
                                             "t.trip_id, " +
                                             "t.service_id, " +
                                             "t.trip_headsign, " +
@@ -517,6 +520,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Ends => "select s.departure_time, " +
                                           "s.stop_id, " +
+                                          "s.stop_sequence, " +
                                           "t.trip_id, " +
                                           "t.service_id, " +
                                           "t.trip_headsign, " +
@@ -543,6 +547,7 @@ public class PostgresStorage : IDataStorage
             
             _ => "select s.departure_time, " +
                         "s.stop_id, " +
+                        "s.stop_sequence, " +
                         "t.trip_id, " +
                         "t.service_id, " +
                         "t.trip_headsign, " +
@@ -579,6 +584,7 @@ public class PostgresStorage : IDataStorage
         {
             ComparisonType.Partial => "select s.departure_time, " +
                                              "s.stop_id, " +
+                                             "s.stop_sequence, " +
                                              "t.trip_id, " +
                                              "t.service_id, " +
                                              "t.trip_headsign, " +
@@ -605,6 +611,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Starts => "select s.departure_time, " +
                                             "s.stop_id, " +
+                                            "s.stop_sequence, " +
                                             "t.trip_id, " +
                                             "t.service_id, " +
                                             "t.trip_headsign, " +
@@ -631,6 +638,7 @@ public class PostgresStorage : IDataStorage
             
             ComparisonType.Ends => "select s.departure_time, " +
                                           "s.stop_id, " +
+                                          "s.stop_sequence, " +
                                           "t.trip_id, " +
                                           "t.service_id, " +
                                           "t.trip_headsign, " +
@@ -657,6 +665,7 @@ public class PostgresStorage : IDataStorage
             
             _ => "select s.departure_time, " +
                         "s.stop_id, " +
+                        "s.stop_sequence, " +
                         "t.trip_id, " +
                         "t.service_id, " +
                         "t.trip_headsign, " +

--- a/NextDepartures.Storage.SqlServer.Aspire/SqlServerStorage.cs
+++ b/NextDepartures.Storage.SqlServer.Aspire/SqlServerStorage.cs
@@ -125,22 +125,23 @@ public class SqlServerStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(i: 1) ? dataReader.GetString(i: 1) : null,
-            TripId = dataReader.GetString(i: 2),
-            ServiceId = dataReader.GetString(i: 3),
-            TripHeadsign = !dataReader.IsDBNull(i: 4) ? dataReader.GetString(i: 4) : null,
-            TripShortName = !dataReader.IsDBNull(i: 5) ? dataReader.GetString(i: 5) : null,
-            AgencyId = !dataReader.IsDBNull(i: 6) ? dataReader.GetString(i: 6) : null,
-            RouteShortName = !dataReader.IsDBNull(i: 7) ? dataReader.GetString(i: 7) : null,
-            RouteLongName = !dataReader.IsDBNull(i: 8) ? dataReader.GetString(i: 8) : null,
-            Monday = dataReader.GetInt16(i: 9).ToBool(),
-            Tuesday = dataReader.GetInt16(i: 10).ToBool(),
-            Wednesday = dataReader.GetInt16(i: 11).ToBool(),
-            Thursday = dataReader.GetInt16(i: 12).ToBool(),
-            Friday = dataReader.GetInt16(i: 13).ToBool(),
-            Saturday = dataReader.GetInt16(i: 14).ToBool(),
-            Sunday = dataReader.GetInt16(i: 15).ToBool(),
-            StartDate = dataReader.GetDateTime(i: 16),
-            EndDate = dataReader.GetDateTime(i: 17)
+            StopSequence = dataReader.GetInt32(i: 2),
+            TripId = dataReader.GetString(i: 3),
+            ServiceId = dataReader.GetString(i: 4),
+            TripHeadsign = !dataReader.IsDBNull(i: 5) ? dataReader.GetString(i: 5) : null,
+            TripShortName = !dataReader.IsDBNull(i: 6) ? dataReader.GetString(i: 6) : null,
+            AgencyId = !dataReader.IsDBNull(i: 7) ? dataReader.GetString(i: 7) : null,
+            RouteShortName = !dataReader.IsDBNull(i: 8) ? dataReader.GetString(i: 8) : null,
+            RouteLongName = !dataReader.IsDBNull(i: 9) ? dataReader.GetString(i: 9) : null,
+            Monday = dataReader.GetInt16(i: 10).ToBool(),
+            Tuesday = dataReader.GetInt16(i: 11).ToBool(),
+            Wednesday = dataReader.GetInt16(i: 12).ToBool(),
+            Thursday = dataReader.GetInt16(i: 13).ToBool(),
+            Friday = dataReader.GetInt16(i: 14).ToBool(),
+            Saturday = dataReader.GetInt16(i: 15).ToBool(),
+            Sunday = dataReader.GetInt16(i: 16).ToBool(),
+            StartDate = dataReader.GetDateTime(i: 17),
+            EndDate = dataReader.GetDateTime(i: 18)
         };
     }
     
@@ -480,6 +481,7 @@ public class SqlServerStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -506,6 +508,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -532,6 +535,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -558,6 +562,7 @@ public class SqlServerStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +
@@ -594,6 +599,7 @@ public class SqlServerStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -620,6 +626,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -646,6 +653,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -672,6 +680,7 @@ public class SqlServerStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +

--- a/NextDepartures.Storage.SqlServer.Aspire/SqlServerStorage.cs
+++ b/NextDepartures.Storage.SqlServer.Aspire/SqlServerStorage.cs
@@ -125,7 +125,7 @@ public class SqlServerStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(i: 1) ? dataReader.GetString(i: 1) : null,
-            StopSequence = dataReader.GetInt32(i: 2),
+            StopSequence = dataReader.GetInt16(i: 2),
             TripId = dataReader.GetString(i: 3),
             ServiceId = dataReader.GetString(i: 4),
             TripHeadsign = !dataReader.IsDBNull(i: 5) ? dataReader.GetString(i: 5) : null,

--- a/NextDepartures.Storage.SqlServer/SqlServerStorage.cs
+++ b/NextDepartures.Storage.SqlServer/SqlServerStorage.cs
@@ -110,7 +110,7 @@ public class SqlServerStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(i: 1) ? dataReader.GetString(i: 1) : null,
-            StopSequence = dataReader.GetInt32(i: 2),
+            StopSequence = dataReader.GetInt16(i: 2),
             TripId = dataReader.GetString(i: 3),
             ServiceId = dataReader.GetString(i: 4),
             TripHeadsign = !dataReader.IsDBNull(i: 5) ? dataReader.GetString(i: 5) : null,

--- a/NextDepartures.Storage.SqlServer/SqlServerStorage.cs
+++ b/NextDepartures.Storage.SqlServer/SqlServerStorage.cs
@@ -110,22 +110,23 @@ public class SqlServerStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(i: 1) ? dataReader.GetString(i: 1) : null,
-            TripId = dataReader.GetString(i: 2),
-            ServiceId = dataReader.GetString(i: 3),
-            TripHeadsign = !dataReader.IsDBNull(i: 4) ? dataReader.GetString(i: 4) : null,
-            TripShortName = !dataReader.IsDBNull(i: 5) ? dataReader.GetString(i: 5) : null,
-            AgencyId = !dataReader.IsDBNull(i: 6) ? dataReader.GetString(i: 6) : null,
-            RouteShortName = !dataReader.IsDBNull(i: 7) ? dataReader.GetString(i: 7) : null,
-            RouteLongName = !dataReader.IsDBNull(i: 8) ? dataReader.GetString(i: 8) : null,
-            Monday = dataReader.GetInt16(i: 9).ToBool(),
-            Tuesday = dataReader.GetInt16(i: 10).ToBool(),
-            Wednesday = dataReader.GetInt16(i: 11).ToBool(),
-            Thursday = dataReader.GetInt16(i: 12).ToBool(),
-            Friday = dataReader.GetInt16(i: 13).ToBool(),
-            Saturday = dataReader.GetInt16(i: 14).ToBool(),
-            Sunday = dataReader.GetInt16(i: 15).ToBool(),
-            StartDate = dataReader.GetDateTime(i: 16),
-            EndDate = dataReader.GetDateTime(i: 17)
+            StopSequence = dataReader.GetInt32(i: 2),
+            TripId = dataReader.GetString(i: 3),
+            ServiceId = dataReader.GetString(i: 4),
+            TripHeadsign = !dataReader.IsDBNull(i: 5) ? dataReader.GetString(i: 5) : null,
+            TripShortName = !dataReader.IsDBNull(i: 6) ? dataReader.GetString(i: 6) : null,
+            AgencyId = !dataReader.IsDBNull(i: 7) ? dataReader.GetString(i: 7) : null,
+            RouteShortName = !dataReader.IsDBNull(i: 8) ? dataReader.GetString(i: 8) : null,
+            RouteLongName = !dataReader.IsDBNull(i: 9) ? dataReader.GetString(i: 9) : null,
+            Monday = dataReader.GetInt16(i: 10).ToBool(),
+            Tuesday = dataReader.GetInt16(i: 11).ToBool(),
+            Wednesday = dataReader.GetInt16(i: 12).ToBool(),
+            Thursday = dataReader.GetInt16(i: 13).ToBool(),
+            Friday = dataReader.GetInt16(i: 14).ToBool(),
+            Saturday = dataReader.GetInt16(i: 15).ToBool(),
+            Sunday = dataReader.GetInt16(i: 16).ToBool(),
+            StartDate = dataReader.GetDateTime(i: 17),
+            EndDate = dataReader.GetDateTime(i: 18)
         };
     }
     
@@ -465,6 +466,7 @@ public class SqlServerStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -491,6 +493,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -517,6 +520,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -543,6 +547,7 @@ public class SqlServerStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +
@@ -579,6 +584,7 @@ public class SqlServerStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -605,6 +611,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -631,6 +638,7 @@ public class SqlServerStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -657,6 +665,7 @@ public class SqlServerStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +

--- a/NextDepartures.Storage.Sqlite/SqliteStorage.cs
+++ b/NextDepartures.Storage.Sqlite/SqliteStorage.cs
@@ -110,22 +110,23 @@ public class SqliteStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            TripId = dataReader.GetString(ordinal: 2),
-            ServiceId = dataReader.GetString(ordinal: 3),
-            TripHeadsign = !dataReader.IsDBNull(ordinal: 4) ? dataReader.GetString(ordinal: 4) : null,
-            TripShortName = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
-            AgencyId = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
-            RouteShortName = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
-            RouteLongName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
-            Monday = dataReader.GetInt16(ordinal: 9).ToBool(),
-            Tuesday = dataReader.GetInt16(ordinal: 10).ToBool(),
-            Wednesday = dataReader.GetInt16(ordinal: 11).ToBool(),
-            Thursday = dataReader.GetInt16(ordinal: 12).ToBool(),
-            Friday = dataReader.GetInt16(ordinal: 13).ToBool(),
-            Saturday = dataReader.GetInt16(ordinal: 14).ToBool(),
-            Sunday = dataReader.GetInt16(ordinal: 15).ToBool(),
-            StartDate = dataReader.GetDateTime(ordinal: 16),
-            EndDate = dataReader.GetDateTime(ordinal: 17)
+            StopSequence = dataReader.GetInt32(ordinal: 2),
+            TripId = dataReader.GetString(ordinal: 3),
+            ServiceId = dataReader.GetString(ordinal: 4),
+            TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,
+            TripShortName = !dataReader.IsDBNull(ordinal: 6) ? dataReader.GetString(ordinal: 6) : null,
+            AgencyId = !dataReader.IsDBNull(ordinal: 7) ? dataReader.GetString(ordinal: 7) : null,
+            RouteShortName = !dataReader.IsDBNull(ordinal: 8) ? dataReader.GetString(ordinal: 8) : null,
+            RouteLongName = !dataReader.IsDBNull(ordinal: 9) ? dataReader.GetString(ordinal: 9) : null,
+            Monday = dataReader.GetInt16(ordinal: 10).ToBool(),
+            Tuesday = dataReader.GetInt16(ordinal: 11).ToBool(),
+            Wednesday = dataReader.GetInt16(ordinal: 12).ToBool(),
+            Thursday = dataReader.GetInt16(ordinal: 13).ToBool(),
+            Friday = dataReader.GetInt16(ordinal: 14).ToBool(),
+            Saturday = dataReader.GetInt16(ordinal: 15).ToBool(),
+            Sunday = dataReader.GetInt16(ordinal: 16).ToBool(),
+            StartDate = dataReader.GetDateTime(ordinal: 17),
+            EndDate = dataReader.GetDateTime(ordinal: 18)
         };
     }
     
@@ -465,6 +466,7 @@ public class SqliteStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -491,6 +493,7 @@ public class SqliteStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -517,6 +520,7 @@ public class SqliteStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -543,6 +547,7 @@ public class SqliteStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +
@@ -579,6 +584,7 @@ public class SqliteStorage : IDataStorage
         {
             ComparisonType.Partial => "SELECT s.DepartureTime, " +
                                              "s.StopId, " +
+                                             "s.StopSequence, " +
                                              "t.TripId, " +
                                              "t.ServiceId, " +
                                              "t.TripHeadsign, " +
@@ -605,6 +611,7 @@ public class SqliteStorage : IDataStorage
             
             ComparisonType.Starts => "SELECT s.DepartureTime, " +
                                             "s.StopId, " +
+                                            "s.StopSequence, " +
                                             "t.TripId, " +
                                             "t.ServiceId, " +
                                             "t.TripHeadsign, " +
@@ -631,6 +638,7 @@ public class SqliteStorage : IDataStorage
             
             ComparisonType.Ends => "SELECT s.DepartureTime, " +
                                           "s.StopId, " +
+                                          "s.StopSequence, " +
                                           "t.TripId, " +
                                           "t.ServiceId, " +
                                           "t.TripHeadsign, " +
@@ -657,6 +665,7 @@ public class SqliteStorage : IDataStorage
             
             _ => "SELECT s.DepartureTime, " +
                         "s.StopId, " +
+                        "s.StopSequence, " +
                         "t.TripId, " +
                         "t.ServiceId, " +
                         "t.TripHeadsign, " +

--- a/NextDepartures.Storage.Sqlite/SqliteStorage.cs
+++ b/NextDepartures.Storage.Sqlite/SqliteStorage.cs
@@ -110,7 +110,7 @@ public class SqliteStorage : IDataStorage
             },
             
             StopId = !dataReader.IsDBNull(ordinal: 1) ? dataReader.GetString(ordinal: 1) : null,
-            StopSequence = dataReader.GetInt32(ordinal: 2),
+            StopSequence = dataReader.GetInt16(ordinal: 2),
             TripId = dataReader.GetString(ordinal: 3),
             ServiceId = dataReader.GetString(ordinal: 4),
             TripHeadsign = !dataReader.IsDBNull(ordinal: 5) ? dataReader.GetString(ordinal: 5) : null,

--- a/NextDepartures.Test/Mock/MockStorage.cs
+++ b/NextDepartures.Test/Mock/MockStorage.cs
@@ -242,7 +242,7 @@ public class MockStorage : IDataStorage
                 },
                 
                 StopId = "16TH",
-                StopSequence = 1,
+                StopSequence = (short)1,
                 TripId = "1561190",
                 ServiceId = "2025_01_21-DX-MVS",
                 TripHeadsign = "San Francisco / Antioch",
@@ -285,7 +285,7 @@ public class MockStorage : IDataStorage
                 },
                 
                 StopId = "16TH",
-                StopSequence = 1,
+                StopSequence = (short)1,
                 TripId = "1561190",
                 ServiceId = "2025_01_21-DX-MVS",
                 TripHeadsign = "San Francisco / Antioch",

--- a/NextDepartures.Test/Mock/MockStorage.cs
+++ b/NextDepartures.Test/Mock/MockStorage.cs
@@ -242,6 +242,7 @@ public class MockStorage : IDataStorage
                 },
                 
                 StopId = "16TH",
+                StopSequence = 1,
                 TripId = "1561190",
                 ServiceId = "2025_01_21-DX-MVS",
                 TripHeadsign = "San Francisco / Antioch",
@@ -284,6 +285,7 @@ public class MockStorage : IDataStorage
                 },
                 
                 StopId = "16TH",
+                StopSequence = 1,
                 TripId = "1561190",
                 ServiceId = "2025_01_21-DX-MVS",
                 TripHeadsign = "San Francisco / Antioch",


### PR DESCRIPTION
## Summary
- include `StopSequence` in `Departure` model
- populate `StopSequence` from GTFS storage
- update SQL storage implementations to read/write `StopSequence`
- adjust mock storage for tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6843222eaa60832bb3be2ff0e16a9b0a