### PR TITLE
Use per-table transactions for inserts

### DIFF
--- a/NextDepartures.Database/Program.cs
+++ b/NextDepartures.Database/Program.cs
@@ -38,9 +38,13 @@ command.CommandText = "INSERT INTO GTFS_AGENCY (" +
 
 command.Parameters.Clear();
 
-foreach (var a in feed.Agencies)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var a in feed.Agencies)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@agencyId",
@@ -83,10 +87,14 @@ foreach (var a in feed.Agencies)
         value: a.Email is not null
             ? a.Email.TrimDoubleQuotes()
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_CALENDAR (" +
@@ -114,9 +122,13 @@ command.CommandText = "INSERT INTO GTFS_CALENDAR (" +
 
 command.Parameters.Clear();
 
-foreach (var c in feed.Calendars)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var c in feed.Calendars)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@serviceId",
@@ -157,10 +169,14 @@ foreach (var c in feed.Calendars)
     command.Parameters.AddWithValue(
         parameterName: "@endDate",
         value: c.EndDate);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_CALENDAR_DATES (" +
@@ -174,9 +190,13 @@ command.CommandText = "INSERT INTO GTFS_CALENDAR_DATES (" +
 
 command.Parameters.Clear();
 
-foreach (var d in feed.CalendarDates)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var d in feed.CalendarDates)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@serviceId",
@@ -189,10 +209,14 @@ foreach (var d in feed.CalendarDates)
     command.Parameters.AddWithValue(
         parameterName: "@exceptionType",
         value: d.ExceptionType);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_FARE_ATTRIBUTES (" +
@@ -214,9 +238,13 @@ command.CommandText = "INSERT INTO GTFS_FARE_ATTRIBUTES (" +
 
 command.Parameters.Clear();
 
-foreach (var f in feed.FareAttributes)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var f in feed.FareAttributes)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@fareId",
@@ -251,10 +279,14 @@ foreach (var f in feed.FareAttributes)
         value: f.TransferDuration is not null
             ? f.TransferDuration.TrimDoubleQuotes()
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_FARE_RULES (" +
@@ -272,9 +304,13 @@ command.CommandText = "INSERT INTO GTFS_FARE_RULES (" +
 
 command.Parameters.Clear();
 
-foreach (var f in feed.FareRules)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var f in feed.FareRules)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@fareId",
@@ -303,10 +339,14 @@ foreach (var f in feed.FareRules)
         value: f.ContainsId is not null
             ? f.ContainsId.TrimDoubleQuotes()
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_FREQUENCIES (" +
@@ -324,9 +364,13 @@ command.CommandText = "INSERT INTO GTFS_FREQUENCIES (" +
 
 command.Parameters.Clear();
 
-foreach (var f in feed.Frequencies)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var f in feed.Frequencies)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@tripId",
@@ -351,10 +395,14 @@ foreach (var f in feed.Frequencies)
                 ? f.ExactTimes
                 : string.Empty
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_LEVELS (" +
@@ -368,9 +416,13 @@ command.CommandText = "INSERT INTO GTFS_LEVELS (" +
 
 command.Parameters.Clear();
 
-foreach (var l in feed.Levels)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var l in feed.Levels)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@levelId",
@@ -385,10 +437,14 @@ foreach (var l in feed.Levels)
         value: l.Name is not null
             ? l.Name.TrimDoubleQuotes()
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_PATHWAYS (" +
@@ -420,9 +476,13 @@ command.CommandText = "INSERT INTO GTFS_PATHWAYS (" +
 
 command.Parameters.Clear();
 
-foreach (var p in feed.Pathways)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var p in feed.Pathways)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@pathwayId",
@@ -487,10 +547,14 @@ foreach (var p in feed.Pathways)
         value: p.ReversedSignpostedAs is not null
             ? p.ReversedSignpostedAs.TrimDoubleQuotes()
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_ROUTES (" +
@@ -516,9 +580,13 @@ command.CommandText = "INSERT INTO GTFS_ROUTES (" +
 
 command.Parameters.Clear();
 
-foreach (var r in feed.Routes)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var r in feed.Routes)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@routeId",
@@ -573,10 +641,14 @@ foreach (var r in feed.Routes)
                 ? r.TextColor
                 : string.Empty
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_SHAPES (" +
@@ -594,9 +666,13 @@ command.CommandText = "INSERT INTO GTFS_SHAPES (" +
 
 command.Parameters.Clear();
 
-foreach (var s in feed.Shapes)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var s in feed.Shapes)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@shapeId",
@@ -619,10 +695,14 @@ foreach (var s in feed.Shapes)
         value: s.DistanceTravelled is not null
             ? s.DistanceTravelled
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_STOPS (" +
@@ -658,9 +738,13 @@ command.CommandText = "INSERT INTO GTFS_STOPS (" +
 
 command.Parameters.Clear();
 
-foreach (var s in feed.Stops)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var s in feed.Stops)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@stopId",
@@ -741,10 +825,14 @@ foreach (var s in feed.Stops)
         value: s.PlatformCode is not null
             ? s.PlatformCode.TrimDoubleQuotes()
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_STOP_TIMES (" +
@@ -772,9 +860,13 @@ command.CommandText = "INSERT INTO GTFS_STOP_TIMES (" +
 
 command.Parameters.Clear();
 
-foreach (var s in feed.StopTimes)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var s in feed.StopTimes)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@tripId",
@@ -835,10 +927,14 @@ foreach (var s in feed.StopTimes)
         value: s.TimepointType.ToString() != string.Empty
             ? s.TimepointType
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_TRANSFERS (" +
@@ -854,9 +950,13 @@ command.CommandText = "INSERT INTO GTFS_TRANSFERS (" +
 
 command.Parameters.Clear();
 
-foreach (var t in feed.Transfers)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var t in feed.Transfers)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@fromStopId",
@@ -881,10 +981,14 @@ foreach (var t in feed.Transfers)
         value: t.MinimumTransferTime is not null
             ? t.MinimumTransferTime
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "INSERT INTO GTFS_TRIPS (" +
@@ -910,9 +1014,13 @@ command.CommandText = "INSERT INTO GTFS_TRIPS (" +
 
 command.Parameters.Clear();
 
-foreach (var t in feed.Trips)
+using (var transaction = connection.BeginTransaction())
 {
-    command.Parameters.Clear();
+    command.Transaction = transaction;
+
+    foreach (var t in feed.Trips)
+    {
+        command.Parameters.Clear();
     
     command.Parameters.AddWithValue(
         parameterName: "@routeId",
@@ -963,10 +1071,14 @@ foreach (var t in feed.Trips)
                 ? t.AccessibilityType
                 : string.Empty
             : DBNull.Value);
-    
-    await command.ExecuteNonQueryAsync();
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    transaction.Commit();
 }
 
+command.Transaction = null;
 command.Parameters.Clear();
 
 command.CommandText = "CREATE INDEX GTFS_STOP_TIMES_INDEX ON GTFS_STOP_TIMES (" +


### PR DESCRIPTION
## Summary
- speed up database initialization
- wrap each GTFS table's inserts in its own transaction

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685dae5364a4832ba1f57104836f84f6