### PR TITLE
Add progress output for transaction loops

### DIFF
--- a/NextDepartures.Database/Program.cs
+++ b/NextDepartures.Database/Program.cs
@@ -6,6 +6,11 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Data.Sqlite;
 using NextDepartures.Database.Extensions;
 
+static void DisplayRowProgress(string label, int row)
+{
+    Console.Write($"\r{label}: row {row}");
+}
+
 GTFSReader<GTFSFeed> reader = new();
 var feed = reader.Read(path: "Data/feed.zip");
 
@@ -54,8 +59,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var a in feed.Agencies)
     {
+        row++;
+        DisplayRowProgress("Agencies", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -104,6 +112,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -138,8 +147,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var c in feed.Calendars)
     {
+        row++;
+        DisplayRowProgress("Calendars", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -186,6 +198,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -206,8 +219,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var d in feed.CalendarDates)
     {
+        row++;
+        DisplayRowProgress("CalendarDates", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -226,6 +242,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -254,8 +271,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var f in feed.FareAttributes)
     {
+        row++;
+        DisplayRowProgress("FareAttributes", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -296,6 +316,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -320,8 +341,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var f in feed.FareRules)
     {
+        row++;
+        DisplayRowProgress("FareRules", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -356,6 +380,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -380,8 +405,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var f in feed.Frequencies)
     {
+        row++;
+        DisplayRowProgress("Frequencies", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -412,6 +440,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -432,8 +461,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var l in feed.Levels)
     {
+        row++;
+        DisplayRowProgress("Levels", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -454,6 +486,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -492,8 +525,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var p in feed.Pathways)
     {
+        row++;
+        DisplayRowProgress("Pathways", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -564,6 +600,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -596,8 +633,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var r in feed.Routes)
     {
+        row++;
+        DisplayRowProgress("Routes", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -658,6 +698,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -682,8 +723,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var s in feed.Shapes)
     {
+        row++;
+        DisplayRowProgress("Shapes", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -712,6 +756,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -754,8 +799,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var s in feed.Stops)
     {
+        row++;
+        DisplayRowProgress("Stops", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -842,6 +890,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -876,8 +925,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var s in feed.StopTimes)
     {
+        row++;
+        DisplayRowProgress("StopTimes", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -944,6 +996,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -966,8 +1019,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var t in feed.Transfers)
     {
+        row++;
+        DisplayRowProgress("Transfers", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -998,6 +1054,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;
@@ -1030,8 +1087,11 @@ using (var transaction = connection.BeginTransaction())
 {
     command.Transaction = transaction;
 
+    var row = 0;
     foreach (var t in feed.Trips)
     {
+        row++;
+        DisplayRowProgress("Trips", row);
         command.Parameters.Clear();
     
     command.AddWithValue(
@@ -1088,6 +1148,7 @@ using (var transaction = connection.BeginTransaction())
     }
 
     transaction.Commit();
+    Console.WriteLine();
 }
 
 command.Transaction = null;


### PR DESCRIPTION
## Summary
- show progress for each data import loop in `NextDepartures.Database`
- update console on a single line while rows are processed

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685db780ab54832ba2009d14bd485c5b